### PR TITLE
slow query出ているクエリにindex追加

### DIFF
--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -257,3 +257,5 @@ CREATE TABLE `admin_users` (
   `deleted_at` bigint default NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+ALTER TABLE user_present_all_received_history ADD INDEX (user_id, present_all_id);


### PR DESCRIPTION

```
mysql> explain SELECT * FROM user_present_all_received_history WHERE user_id=10208648 AND present_all_id=27;
+----+-------------+-----------------------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
| id | select_type | table                             | partitions | type | possible_keys | key  | key_len | ref  | rows   | filtered | Extra       |
+----+-------------+-----------------------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
|  1 | SIMPLE      | user_present_all_received_history | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 240876 |     1.00 | Using where |
+----+-------------+-----------------------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
1 row in set, 1 warning (0.00 sec)

mysql> ALTER TABLE user_present_all_received_history ADD INDEX(user_id, present_all_id);
Query OK, 0 rows affected (2.16 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> explain SELECT * FROM user_present_all_received_history WHERE user_id=10208648 AND present_all_id=27;
+----+-------------+-----------------------------------+------------+------+---------------+---------+---------+-------------+------+----------+-------+
| id | select_type | table                             | partitions | type | possible_keys | key     | key_len | ref         | rows | filtered | Extra |
+----+-------------+-----------------------------------+------------+------+---------------+---------+---------+-------------+------+----------+-------+
|  1 | SIMPLE      | user_present_all_received_history | NULL       | ref  | user_id       | user_id | 16      | const,const |    1 |   100.00 | NULL  |
+----+-------------+-----------------------------------+------------+------+---------------+---------+---------+-------------+------+----------+-------+
1 row in set, 1 warning (0.00 sec)
```