### PR TITLE
createUserのgenerateIDを消すぞ〜

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -548,7 +548,7 @@ func (h *Handler) obtainItem(tx *sqlx.Tx, userID, itemID int64, itemType int, ob
 		// id再取得
 		query = "SELECT LAST_INSERT_ID()"
 		if err = tx.Get(&card.ID, query); err != nil {
-			return errorResponse(c, http.StatusInternalServerError, err)
+			return nil, nil, nil, err
 		}
 
 		obtainCards = append(obtainCards, card)

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -847,24 +847,19 @@ func (h *Handler) login(c echo.Context) error {
 	if _, err = tx.Exec(query, requestAt, req.UserID); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
-	sID, err := h.generateID()
-	if err != nil {
-		return errorResponse(c, http.StatusInternalServerError, err)
-	}
 	sessID, err := generateUUID()
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 	sess := &Session{
-		ID:        sID,
 		UserID:    req.UserID,
 		SessionID: sessID,
 		CreatedAt: requestAt,
 		UpdatedAt: requestAt,
 		ExpiredAt: requestAt + 86400,
 	}
-	query = "INSERT INTO user_sessions(id, user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
-	if _, err = tx.Exec(query, sess.ID, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
+	query = "INSERT INTO user_sessions(user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
+	if _, err = tx.Exec(query, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1640,7 +1640,7 @@ func (h *Handler) updateDeck(c echo.Context) error {
 	}
 
 	// id再取得
-	query = "SELECT id from user_decks ORDER BY id DESC LIMIT 1"
+	query = "SELECT LAST_INSERT_ID() FROM user_decks limit 1"
 	if err = tx.Get(newDeck.ID, query); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1635,7 +1635,7 @@ func (h *Handler) updateDeck(c echo.Context) error {
 	}
 
 	// id再取得
-	query = "SELECT LAST_INSERT_ID() FROM user_decks limit 1"
+	query = "SELECT LAST_INSERT_ID()"
 	if err = tx.Get(newDeck.ID, query); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -362,12 +362,7 @@ func (h *Handler) obtainLoginBonus(tx *sqlx.Tx, userID int64, requestAt int64) (
 			}
 			initBonus = true
 
-			ubID, err := h.generateID()
-			if err != nil {
-				return nil, err
-			}
 			userBonus = &UserLoginBonus{
-				ID:                 ubID,
 				UserID:             userID,
 				LoginBonusID:       bonus.ID,
 				LastRewardSequence: 0,
@@ -408,8 +403,13 @@ func (h *Handler) obtainLoginBonus(tx *sqlx.Tx, userID int64, requestAt int64) (
 
 		// 進捗の保存
 		if initBonus {
-			query = "INSERT INTO user_login_bonuses(id, user_id, login_bonus_id, last_reward_sequence, loop_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-			if _, err = tx.Exec(query, userBonus.ID, userBonus.UserID, userBonus.LoginBonusID, userBonus.LastRewardSequence, userBonus.LoopCount, userBonus.CreatedAt, userBonus.UpdatedAt); err != nil {
+			query = "INSERT INTO user_login_bonuses(user_id, login_bonus_id, last_reward_sequence, loop_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+			if _, err = tx.Exec(query, userBonus.UserID, userBonus.LoginBonusID, userBonus.LastRewardSequence, userBonus.LoopCount, userBonus.CreatedAt, userBonus.UpdatedAt); err != nil {
+				return nil, err
+			}
+			// id再取得
+			query = "SELECT LAST_INSERT_ID()"
+			if err := tx.Get(&userBonus.ID, query); err != nil {
 				return nil, err
 			}
 		} else {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1353,7 +1353,6 @@ func (h *Handler) listItem(c echo.Context) error {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 	token := &UserOneTimeToken{
-		ID:        tID,
 		UserID:    userID,
 		Token:     tk,
 		TokenType: 2,

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -859,7 +859,7 @@ func (h *Handler) login(c echo.Context) error {
 		UpdatedAt: requestAt,
 		ExpiredAt: requestAt + 86400,
 	}
-	query = "INSERT INTO user_sessions(user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
+	query = "INSERT INTO user_sessions(user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?)"
 	if _, err = tx.Exec(query, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1636,7 +1636,7 @@ func (h *Handler) updateDeck(c echo.Context) error {
 
 	// id再取得
 	query = "SELECT LAST_INSERT_ID()"
-	if err = tx.Get(newDeck.ID, query); err != nil {
+	if err = tx.Get(&newDeck.ID, query); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -684,6 +684,7 @@ func (h *Handler) createUser(c echo.Context) error {
 		CreatedAt:    requestAt,
 		UpdatedAt:    requestAt,
 	}
+
 	query = "INSERT INTO user_devices(user_id, platform_id, platform_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)"
 	_, err = tx.Exec(query, user.ID, req.ViewerID, req.PlatformType, requestAt, requestAt)
 	if err != nil {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1640,7 +1640,7 @@ func (h *Handler) updateDeck(c echo.Context) error {
 	}
 
 	// id再取得
-	query = "SELECT LAST_INSERT_ID()"
+	query = "SELECT id from user_decks ORDER BY id DESC LIMIT 1"
 	if err = tx.Get(newDeck.ID, query); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -974,16 +974,11 @@ func (h *Handler) listGacha(c echo.Context) error {
 	if _, err = h.DB.Exec(query, requestAt, userID); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
-	tID, err := h.generateID()
-	if err != nil {
-		return errorResponse(c, http.StatusInternalServerError, err)
-	}
 	tk, err := generateUUID()
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 	token := &UserOneTimeToken{
-		ID:        tID,
 		UserID:    userID,
 		Token:     tk,
 		TokenType: 1,
@@ -991,8 +986,8 @@ func (h *Handler) listGacha(c echo.Context) error {
 		UpdatedAt: requestAt,
 		ExpiredAt: requestAt + 600,
 	}
-	query = "INSERT INTO user_one_time_tokens(id, user_id, token, token_type, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-	if _, err = h.DB.Exec(query, token.ID, token.UserID, token.Token, token.TokenType, token.CreatedAt, token.UpdatedAt, token.ExpiredAt); err != nil {
+	query = "INSERT INTO user_one_time_tokens(user_id, token, token_type, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
+	if _, err = h.DB.Exec(query, token.UserID, token.Token, token.TokenType, token.CreatedAt, token.UpdatedAt, token.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 
@@ -1357,10 +1352,6 @@ func (h *Handler) listItem(c echo.Context) error {
 	if _, err = h.DB.Exec(query, requestAt, userID); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
-	tID, err := h.generateID()
-	if err != nil {
-		return errorResponse(c, http.StatusInternalServerError, err)
-	}
 	tk, err := generateUUID()
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
@@ -1374,8 +1365,8 @@ func (h *Handler) listItem(c echo.Context) error {
 		UpdatedAt: requestAt,
 		ExpiredAt: requestAt + 600,
 	}
-	query = "INSERT INTO user_one_time_tokens(id, user_id, token, token_type, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-	if _, err = h.DB.Exec(query, token.ID, token.UserID, token.Token, token.TokenType, token.CreatedAt, token.UpdatedAt, token.ExpiredAt); err != nil {
+	query = "INSERT INTO user_one_time_tokens(user_id, token, token_type, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
+	if _, err = h.DB.Exec(query, token.UserID, token.Token, token.TokenType, token.CreatedAt, token.UpdatedAt, token.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -668,7 +668,7 @@ func (h *Handler) createUser(c echo.Context) error {
 		UpdatedAt:       requestAt,
 	}
 	query := "INSERT INTO users(last_activated_at, registered_at, last_getreward_at, created_at, updated_at) VALUES(?, ?, ?, ?, ?)"
-	if _, err = tx.Exec(query, user.LastActivatedAt, user.RegisteredAt, user.LastGetRewardAt, user.CreatedAt, user.UpdatedAt); err != nil {
+	if _, err := tx.Exec(query, user.LastActivatedAt, user.RegisteredAt, user.LastGetRewardAt, user.CreatedAt, user.UpdatedAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 	// id再取得
@@ -685,7 +685,7 @@ func (h *Handler) createUser(c echo.Context) error {
 		UpdatedAt:    requestAt,
 	}
 	query = "INSERT INTO user_devices(user_id, platform_id, platform_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)"
-	_, err = tx.Exec(query, user.ID, req.ViewerID, req.PlatformType, requestAt, requestAt)
+	_, err := tx.Exec(query, user.ID, req.ViewerID, req.PlatformType, requestAt, requestAt)
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
@@ -698,7 +698,7 @@ func (h *Handler) createUser(c echo.Context) error {
 	// 初期デッキ付与
 	initCard := new(ItemMaster)
 	query = "SELECT * FROM item_masters WHERE id=?"
-	if err = tx.Get(initCard, query, 2); err != nil {
+	if err := tx.Get(initCard, query, 2); err != nil {
 		if err == sql.ErrNoRows {
 			return errorResponse(c, http.StatusNotFound, ErrItemNotFound)
 		}
@@ -775,11 +775,11 @@ func (h *Handler) createUser(c echo.Context) error {
 		ExpiredAt: requestAt + 86400,
 	}
 	query = "INSERT INTO user_sessions(user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?)"
-	if _, err = tx.Exec(query, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
+	if _, err := tx.Exec(query, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 
-	err = tx.Commit()
+	err := tx.Commit()
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -760,20 +760,16 @@ func (h *Handler) createUser(c echo.Context) error {
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
-	sessID, err := generateUUID()
-	if err != nil {
-		return errorResponse(c, http.StatusInternalServerError, err)
-	}
+
 	sess := &Session{
 		ID:        sID,
 		UserID:    user.ID,
-		SessionID: sessID,
 		CreatedAt: requestAt,
 		UpdatedAt: requestAt,
 		ExpiredAt: requestAt + 86400,
 	}
-	query = "INSERT INTO user_sessions(id, user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
-	if _, err = tx.Exec(query, sess.ID, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
+	query = "INSERT INTO user_sessions(user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
+	if _, err = tx.Exec(query, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -547,7 +547,7 @@ func (h *Handler) obtainItem(tx *sqlx.Tx, userID, itemID int64, itemType int, ob
 
 		// id再取得
 		query = "SELECT LAST_INSERT_ID()"
-		if err = tx.Get(&card.ID, query); err != nil {
+		if err := tx.Get(&card.ID, query); err != nil {
 			return nil, nil, nil, err
 		}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1634,14 +1634,14 @@ func (h *Handler) updateDeck(c echo.Context) error {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 
-	err = tx.Commit()
-	if err != nil {
-		return errorResponse(c, http.StatusInternalServerError, err)
-	}
-
 	// id再取得
 	query = "SELECT LAST_INSERT_ID() FROM user_decks limit 1"
 	if err = tx.Get(newDeck.ID, query); err != nil {
+		return errorResponse(c, http.StatusInternalServerError, err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -466,22 +466,16 @@ func (h *Handler) obtainPresent(tx *sqlx.Tx, userID int64, requestAt int64) ([]*
 			return nil, err
 		}
 
-		phID, err := h.generateID()
-		if err != nil {
-			return nil, err
-		}
 		history := &UserPresentAllReceivedHistory{
-			ID:           phID,
 			UserID:       userID,
 			PresentAllID: np.ID,
 			ReceivedAt:   requestAt,
 			CreatedAt:    requestAt,
 			UpdatedAt:    requestAt,
 		}
-		query = "INSERT INTO user_present_all_received_history(id, user_id, present_all_id, received_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+		query = "INSERT INTO user_present_all_received_history(user_id, present_all_id, received_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)"
 		if _, err := tx.Exec(
 			query,
-			history.ID,
 			history.UserID,
 			history.PresentAllID,
 			history.ReceivedAt,

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -685,7 +685,7 @@ func (h *Handler) createUser(c echo.Context) error {
 		UpdatedAt:    requestAt,
 	}
 	query = "INSERT INTO user_devices(user_id, platform_id, platform_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)"
-	_, err := tx.Exec(query, user.ID, req.ViewerID, req.PlatformType, requestAt, requestAt)
+	_, err = tx.Exec(query, user.ID, req.ViewerID, req.PlatformType, requestAt, requestAt)
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
@@ -779,7 +779,7 @@ func (h *Handler) createUser(c echo.Context) error {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 
-	err := tx.Commit()
+	err = tx.Commit()
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -755,17 +755,11 @@ func (h *Handler) createUser(c echo.Context) error {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 
-	// セッション発行
-	sID, err := h.generateID()
-	if err != nil {
-		return errorResponse(c, http.StatusInternalServerError, err)
-	}
 	sessID, err := generateUUID()
 	if err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 	sess := &Session{
-		ID:        sID,
 		UserID:    user.ID,
 		SessionID: sessID,
 		CreatedAt: requestAt,
@@ -773,7 +767,7 @@ func (h *Handler) createUser(c echo.Context) error {
 		ExpiredAt: requestAt + 86400,
 	}
 	query = "INSERT INTO user_sessions(id, user_id, session_id, created_at, updated_at, expired_at) VALUES (?, ?, ?, ?, ?, ?)"
-	if _, err = tx.Exec(query, sess.ID, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
+	if _, err = tx.Exec(query, sess.UserID, sess.SessionID, sess.CreatedAt, sess.UpdatedAt, sess.ExpiredAt); err != nil {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -573,12 +573,7 @@ func (h *Handler) obtainItem(tx *sqlx.Tx, userID, itemID int64, itemType int, ob
 		}
 
 		if uitem == nil {
-			uitemID, err := h.generateID()
-			if err != nil {
-				return nil, nil, nil, err
-			}
 			uitem = &UserItem{
-				ID:        uitemID,
 				UserID:    userID,
 				ItemType:  item.ItemType,
 				ItemID:    item.ID,
@@ -586,8 +581,14 @@ func (h *Handler) obtainItem(tx *sqlx.Tx, userID, itemID int64, itemType int, ob
 				CreatedAt: requestAt,
 				UpdatedAt: requestAt,
 			}
-			query = "INSERT INTO user_items(id, user_id, item_id, item_type, amount, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-			if _, err := tx.Exec(query, uitem.ID, userID, uitem.ItemID, uitem.ItemType, uitem.Amount, requestAt, requestAt); err != nil {
+			query = "INSERT INTO user_items(user_id, item_id, item_type, amount, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+			if _, err := tx.Exec(query, userID, uitem.ItemID, uitem.ItemType, uitem.Amount, requestAt, requestAt); err != nil {
+				return nil, nil, nil, err
+			}
+
+			// id再取得
+			query = "SELECT LAST_INSERT_ID()"
+			if err := tx.Get(&uitem.ID, query); err != nil {
 				return nil, nil, nil, err
 			}
 

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -56,7 +56,7 @@ CREATE TABLE `user_bans` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `user_devices` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL comment 'ユーザID', 
   `platform_id` varchar(255) NOT NULL comment 'プラットフォームのviewer_id',
   `platform_type` int(1) NOT NULL comment 'PC:1,iOS:2,Android:3', 

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -93,7 +93,7 @@ CREATE TABLE `login_bonus_reward_masters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `user_login_bonuses` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL comment 'ユーザID', 
   `login_bonus_id` int NOT NULL comment 'ログインボーナスID',
   `last_reward_sequence` int NOT NULL comment '最終受け取り報酬番号',
@@ -122,7 +122,7 @@ CREATE TABLE `present_all_masters` (
 /* 全員プレゼント履歴テーブル */
 
 CREATE TABLE `user_present_all_received_history` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL comment '受けとったユーザID',
   `present_all_id` bigint NOT NULL comment '全員プレゼントマスタのID',
   `received_at` bigint NOT NULL comment '受け取った日時',

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -21,7 +21,7 @@ DROP TABLE IF EXISTS `version_masters`;
 DROP TABLE IF EXISTS `admin_users`;
 
 CREATE TABLE `users` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `isu_coin` bigint NOT NULL default 0 comment '所持ISU-COIN',
   `last_getreward_at` bigint NOT NULL comment '最後にリワードを取得した日時',
   `last_activated_at` bigint NOT NULL comment '最終アクティブ日時',

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -157,7 +157,7 @@ CREATE TABLE `gacha_item_masters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `user_items` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL comment 'ユーザID',
   `item_type` int(1) NOT NULL comment 'アイテム種別:1はusersテーブル、2はuser_cardsへ。3,4をこのテーブルへ保存',
   `item_id` int NOT NULL comment 'アイテムID',

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -170,7 +170,7 @@ CREATE TABLE `user_items` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `user_cards` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL comment 'ユーザID',
   `card_id` int NOT NULL comment '装備のID',
   `amount_per_sec` int NOT NULL comment '生産性（ISU/sec)',

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -210,7 +210,7 @@ CREATE TABLE `version_masters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `user_sessions` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL,
   `session_id` varchar(128) NOT NULL,
   `created_at` bigint NOT NULL,

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -33,7 +33,7 @@ CREATE TABLE `users` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `user_decks` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL comment 'ユーザID', 
   `user_card_id_1` bigint NOT NULL comment '装備枠1',
   `user_card_id_2` bigint NOT NULL comment '装備枠2',

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -223,7 +223,7 @@ CREATE TABLE `user_sessions` (
 
 /* 更新処理について利用するone time tokenの管理 */
 CREATE TABLE `user_one_time_tokens` (
-  `id` bigint NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `user_id` bigint NOT NULL,
   `token` varchar(128) NOT NULL,
   `token_type` int(2) NOT NULL comment '1:ガチャ用、2:カード強化用',


### PR DESCRIPTION
#1

createUserのgenerateUUIDを消してauto incrementでinsertしてくれるか実験
```
05:53:47.796221 [ValidationScenario] 整合性チェックを終了します
05:53:47.796245 整合性チェックに失敗しました
05:53:50.798503 [VALIDATION_ERR] prepare: validation-error-invalid-response-body: GET  /admin/user/7380937147 の Body の userPresents の個数 が違います : expected(158) != actual(182)
05:53:50.798528 続行不可能なエラーが検出されたので、ここで処理を終了します。
05:53:50.798542 [PASSED]: false
05:53:50.798548 [SCORE] 0 (addition: 0, deduction: 0)
[ADMIN] 05:53:50.798584 [SCORE] map[GET /user/:userId/gacha/index:0 GET /user/:userId/home:0 GET /user/:userId/item:0 GET /user/:userId/present/index/:n:0 POST /login:0 POST /login(ban):0 POST /user:0 POST /user/:userId/card:0 POST /user/:userId/card/addexp/:cardId:0 POST /user/:userId/gacha/draw/:gachaId:0 POST /user/:userId/present/receive:0 POST /user/:userId/reward:0]
```