### PR TITLE
未配布のプレゼントのみを取得するように修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -436,24 +436,13 @@ func (h *Handler) obtainLoginBonus(tx *sqlx.Tx, userID int64, requestAt int64) (
 // obtainPresent プレゼント付与
 func (h *Handler) obtainPresent(tx *sqlx.Tx, userID int64, requestAt int64) ([]*UserPresent, error) {
 	normalPresents := make([]*PresentAllMaster, 0)
-	query := "SELECT * FROM present_all_masters WHERE registered_start_at <= ? AND registered_end_at >= ?"
-	if err := tx.Select(&normalPresents, query, requestAt, requestAt); err != nil {
+	query := "SELECT * FROM present_all_masters WHERE registered_start_at <= ? AND registered_end_at >= ? AND id NOT IN (SELECT present_all_id FROM user_present_all_received_history WHERE user_id = ?)"
+	if err := tx.Select(&normalPresents, query, requestAt, requestAt, userID); err != nil {
 		return nil, err
 	}
 
 	obtainPresents := make([]*UserPresent, 0)
 	for _, np := range normalPresents {
-		received := new(UserPresentAllReceivedHistory)
-		query = "SELECT * FROM user_present_all_received_history WHERE user_id=? AND present_all_id=?"
-		err := tx.Get(received, query, userID, np.ID)
-		if err == nil {
-			// プレゼント配布済
-			continue
-		}
-		if err != sql.ErrNoRows {
-			return nil, err
-		}
-
 		pID, err := h.generateID()
 		if err != nil {
 			return nil, err

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -259,3 +259,5 @@ CREATE TABLE `admin_users` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 ALTER TABLE user_present_all_received_history ADD INDEX (user_id, present_all_id);
+ALTER TABLE present_all_masters ADD INDEX (registered_start_at);
+

--- a/webapp/sql/3_schema_exclude_user_presents.sql
+++ b/webapp/sql/3_schema_exclude_user_presents.sql
@@ -260,6 +260,4 @@ CREATE TABLE `admin_users` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
-ALTER TABLE user_present_all_received_history ADD INDEX (user_id, present_all_id);
-ALTER TABLE present_all_masters ADD INDEX (registered_start_at);
 ALTER TABLE user_presents MODIFY COLUMN `id` bigint NOT NULL AUTO_INCREMENT;


### PR DESCRIPTION
この辺でのプロファイリングによりやや遅そうな雰囲気を感じた。
https://github.com/pinkumohikan/isucon-practice-20221001/issues/1#issuecomment-1264266539

全員プレゼントなものを取得したあと、自分は受け取り済みかどうかを判定するロジックになってN+1になっている。
これをまだ受け取っていない全員プレゼントのみを取得するように修正する。
