### PR TITLE
初期データ投入後、performance_schemaをリセットする

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -630,6 +630,10 @@ func initialize(c echo.Context) error {
 		return errorResponse(c, http.StatusInternalServerError, err)
 	}
 
+	if _, err := dbx.Exec("CALL sys.ps_truncate_all_tables(FALSE)"); err != nil {
+		return errorResponse(c, http.StatusInternalServerError, err)
+	}
+
 	return successResponse(c, &InitializeResponse{
 		Language: "go",
 	})


### PR DESCRIPTION
テーブルごとのI/O回数を見れる便利クエリを見つけたが、initialize処理によるI/O回数が混ざっている。
https://github.com/pinkumohikan/isucon-practice-20221001/issues/1#issuecomment-1264288839

`CALL sys.ps_truncate_all_tables(FALSE)` を叩くとperformance_schemaをリセットできるらしいので、初期データの投入後に叩くようにする。

https://dev.mysql.com/doc/refman/5.7/en/sys-ps-truncate-all-tables.html